### PR TITLE
Add improved box sampling and specification

### DIFF
--- a/Assets/Scripts/Controllers/PlayController.cs
+++ b/Assets/Scripts/Controllers/PlayController.cs
@@ -120,7 +120,7 @@ public class PlayController : ISceneController
         toppingsDisplay.SetPizzaOrder(currPizzaOrder);
 
         // Ship meat
-        DeliveryManager.dmInstance.DeliverMeat(currPizzaOrder.meats, currPizzaOrder.numMeatToShip);
+        DeliveryManager.dmInstance.DeliverMeat(currPizzaOrder.meats, currPizzaOrder.numBoxesToShip);
     }
 
     public void EndLevel()
@@ -222,7 +222,7 @@ public class PlayController : ISceneController
 
     public bool AddMeat(IngredientTypes.Meats meat)
     {
-        if (!currPizzaOrder.meats.Contains(meat))
+        if (!Utilities.containsMeat(currPizzaOrder.meats, meat))
         {
             return false;
         }

--- a/Assets/Scripts/GameObjects/ConveyorBelt/Pizza.cs
+++ b/Assets/Scripts/GameObjects/ConveyorBelt/Pizza.cs
@@ -94,9 +94,9 @@ public class Pizza : InteractableObject
     {
         SetSauce(pizzaOrder.sauce);
         SetCheese(pizzaOrder.cheese);
-        foreach (IngredientTypes.Meats meat in pizzaOrder.meats)
+        foreach (PizzaOrder.MeatItem meatItem in pizzaOrder.meats)
         {
-            AddMeat(meat);
+            AddMeat(meatItem.meatType);
         }
         foreach (IngredientTypes.Peppers pepper in pizzaOrder.peppers)
         {
@@ -255,9 +255,9 @@ public class Pizza : InteractableObject
         {
             return false;
         }
-        foreach (IngredientTypes.Meats meat in pizzaOrder.meats)
+        foreach (PizzaOrder.MeatItem meatItem in pizzaOrder.meats)
         {
-            if (!pizzaData.meats.Contains(meat))
+            if (!pizzaData.meats.Contains(meatItem.meatType))
             {
                 return false;
             }

--- a/Assets/Scripts/GameObjects/ToppingsDisplay/ToppingsDisplay.cs
+++ b/Assets/Scripts/GameObjects/ToppingsDisplay/ToppingsDisplay.cs
@@ -105,7 +105,7 @@ public class ToppingsDisplay : MonoBehaviour
         List<Texture2D> toppings = new List<Texture2D>();
         foreach (MeatImage meatImage in meatImages)
         {
-            if (pizzaOrder.meats.Contains(meatImage.meat))
+            if (Utilities.containsMeat(pizzaOrder.meats, meatImage.meat))
             {
                 toppings.Add(meatImage.image);
             }

--- a/Assets/Scripts/Managers/DeliveryManager.cs
+++ b/Assets/Scripts/Managers/DeliveryManager.cs
@@ -1,7 +1,10 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 
+using Random = UnityEngine.Random;
 
 // Handle generating x boxes with required list + random to reach total y
 // Send off to delivery table
@@ -11,8 +14,8 @@ public class DeliveryManager : MonoBehaviour
     public static DeliveryManager dmInstance = null;
 
     // List of all meat types cuz I couldnt generate a list of all meat types automatically cuz unity ;-;
-    [SerializeField]
-    public List<IngredientTypes.Meats> meatTypes;
+    // I was wrong - literally the first bing search pulls this up
+    public HashSet<Constants.Meats> meatTypes = Enum.GetValues(typeof(Constants.Meats)).Cast<Constants.Meats>().ToHashSet();
 
     public void Awake() {
         if ( null == dmInstance ) {
@@ -28,8 +31,10 @@ public class DeliveryManager : MonoBehaviour
     // This way, we don't have to flood the player with boxes early in the game
     public bool DeliverMeat(List<PizzaOrder.MeatItem> requiredMeats, int maxBoxesToDeliver=Constants.MAX_MEAT_DELIVERY_SPOTS)
     {
+        int totalBoxesRequired = requiredMeats.Aggregate(0, (total, meatItem) => total + meatItem.numBoxes);
+
         // Cant deliver enough
-        if ( requiredMeats.Count > Constants.MAX_MEAT_DELIVERY_SPOTS )
+        if ( totalBoxesRequired > Constants.MAX_MEAT_DELIVERY_SPOTS || maxBoxesToDeliver > Constants.MAX_MEAT_DELIVERY_SPOTS )
         {
             return false;
         }
@@ -38,7 +43,6 @@ public class DeliveryManager : MonoBehaviour
         // Set number of boxes to be delivered to be equal to required meats
         // ie. I need one box of pepperoni, but for whatever reason, I pass in maxBoxesToDeliver as 0
         // I want maxBoxesToDeliver to be 1 so I still get the pepperoni box
-        int totalBoxesRequired = GetTotalBoxesCount( requiredMeats );
         if ( maxBoxesToDeliver < totalBoxesRequired )
         {
             maxBoxesToDeliver = totalBoxesRequired;

--- a/Assets/Scripts/Managers/DeliveryManager.cs
+++ b/Assets/Scripts/Managers/DeliveryManager.cs
@@ -15,7 +15,7 @@ public class DeliveryManager : MonoBehaviour
 
     // List of all meat types cuz I couldnt generate a list of all meat types automatically cuz unity ;-;
     // I was wrong - literally the first bing search pulls this up
-    public HashSet<Constants.Meats> meatTypes = Enum.GetValues(typeof(Constants.Meats)).Cast<Constants.Meats>().ToHashSet();
+    public HashSet<IngredientTypes.Meats> meatTypes = Enum.GetValues(typeof(IngredientTypes.Meats)).Cast<IngredientTypes.Meats>().ToHashSet();
 
     public void Awake() {
         if ( null == dmInstance ) {
@@ -49,7 +49,7 @@ public class DeliveryManager : MonoBehaviour
         }
         
         // Populate list up to maxBoxes to deliver
-        List<Constants.Meats> meatBoxes = PopulateMeatList(requiredMeats, maxBoxesToDeliver, totalBoxesRequired);
+        List<IngredientTypes.Meats> meatBoxes = PopulateMeatList(requiredMeats, maxBoxesToDeliver, totalBoxesRequired);
 
         // Tell table to create and deliver them
         // Returns true if we did deliver the boxes
@@ -57,9 +57,9 @@ public class DeliveryManager : MonoBehaviour
     }
 
     // Create list of meats
-    private List<Constants.Meats> PopulateMeatList(List<PizzaOrder.MeatItem> requiredMeats, int boxesToDeliver, int totalBoxesRequired)
+    private List<IngredientTypes.Meats> PopulateMeatList(List<PizzaOrder.MeatItem> requiredMeats, int boxesToDeliver, int totalBoxesRequired)
     {
-        List<Constants.Meats> finalMeats = new List<Constants.Meats>();
+        List<IngredientTypes.Meats> finalMeats = new List<IngredientTypes.Meats>();
 
         // Copy over required meats
         foreach ( PizzaOrder.MeatItem meatItem in requiredMeats )
@@ -74,12 +74,12 @@ public class DeliveryManager : MonoBehaviour
         // Need to fill in with random meat up to boxes to deliver
         if ( boxesToDeliver - totalBoxesRequired > 0 )
         {
-            List<Constants.Meats> uniqueMeats = CreateUniqueMeatList(requiredMeats);
+            List<IngredientTypes.Meats> uniqueMeats = CreateUniqueMeatList(requiredMeats);
 
             for ( int i = 0; i < boxesToDeliver - totalBoxesRequired; i++ )
             {
                 int meatIdx = Random.Range(0, uniqueMeats.Count);
-                Constants.Meats meatType = uniqueMeats[meatIdx];
+                IngredientTypes.Meats meatType = uniqueMeats[meatIdx];
 
                 // Eh what the heck - let's just add to required meats and return that...
                 // This bit me in the butt gosh darn it - make a new list <_<
@@ -112,11 +112,11 @@ public class DeliveryManager : MonoBehaviour
 
     // Create unique list of meats that exludes the required meat boxes
     // eg. if I want pepperoni as a meat, this list will not contain pepperoni
-    private List<Constants.Meats> CreateUniqueMeatList(List<PizzaOrder.MeatItem> meats)
+    private List<IngredientTypes.Meats> CreateUniqueMeatList(List<PizzaOrder.MeatItem> meats)
     {
-        List<Constants.Meats> uniqueMeats = new List<Constants.Meats>();
+        List<IngredientTypes.Meats> uniqueMeats = new List<IngredientTypes.Meats>();
 
-        foreach ( Constants.Meats meat in meatTypes )
+        foreach ( IngredientTypes.Meats meat in meatTypes )
         {
             if ( !Utilities.containsMeat(meats, meat) )
             {

--- a/Assets/Scripts/Managers/DeliveryManager.cs
+++ b/Assets/Scripts/Managers/DeliveryManager.cs
@@ -98,18 +98,6 @@ public class DeliveryManager : MonoBehaviour
         return finalMeats;
     }
 
-    private int GetTotalBoxesCount(List<PizzaOrder.MeatItem> meats)
-    {
-        int total = 0;
-
-        foreach ( PizzaOrder.MeatItem meatItem in meats )
-        {
-            total += meatItem.numBoxes;
-        }
-
-        return ( total );
-    }
-
     // Create unique list of meats that exludes the required meat boxes
     // eg. if I want pepperoni as a meat, this list will not contain pepperoni
     private List<IngredientTypes.Meats> CreateUniqueMeatList(List<PizzaOrder.MeatItem> meats)

--- a/Assets/Scripts/ScriptableObjects/PizzaOrder.cs
+++ b/Assets/Scripts/ScriptableObjects/PizzaOrder.cs
@@ -4,17 +4,31 @@ using System.Collections.Generic;
 [CreateAssetMenu(fileName = "Data", menuName = "ScriptableObjects/PizzaOrder", order = 1)]
 public class PizzaOrder : ScriptableObject
 {
+    // To make the hashtable kinda serializable
+    [System.Serializable]
+    public struct MeatItem
+    {
+        // Meat type
+        [SerializeField]
+        public IngredientTypes.Meats meatType;
+
+        // Number of boxes for specified meat type
+        [SerializeField]
+        public int numBoxes;
+    }
+
+    public bool hasPineapple;
     public IngredientTypes.Sauces sauce;
     public IngredientTypes.CheeseTypes cheese;
-    public List<IngredientTypes.Meats> meats;
     public List<IngredientTypes.Peppers> peppers;
     public List<IngredientTypes.Vegetables> vegetables;
     public List<IngredientTypes.GenericToppings> genericToppings;
-    public bool hasPineapple;
+
+    public List<MeatItem> meats;
 
     // Note: this specifies the total number of boxes to ship
     // If you specify 1 meat required and 4 boxes to ship:
     // 1 box will be the required meat
     // 3 boxes will be random sample from the meat options
-    public int numMeatToShip;
+    public int numBoxesToShip;
 }

--- a/Assets/Scripts/Utils/Utilities.cs
+++ b/Assets/Scripts/Utils/Utilities.cs
@@ -14,7 +14,7 @@ public class Utilities
         return ( numDigits );
     }
 
-    public static bool containsMeat( List<PizzaOrder.MeatItem> meats, Constants.Meats meatType )
+    public static bool containsMeat( List<PizzaOrder.MeatItem> meats, IngredientTypes.Meats meatType )
     {
         return ( meats.FindIndex(meatItem => meatItem.meatType == meatType)  != -1 );
     }

--- a/Assets/Scripts/Utils/Utilities.cs
+++ b/Assets/Scripts/Utils/Utilities.cs
@@ -1,4 +1,5 @@
 using UnityEngine;
+using System.Collections.Generic;
 
 public class Utilities
 {
@@ -11,5 +12,18 @@ public class Utilities
         numDigits = (int)Mathf.Floor( Mathf.Log10( num ) + 1 );
 
         return ( numDigits );
+    }
+
+    public static bool containsMeat( List<PizzaOrder.MeatItem> meats, Constants.Meats meatType )
+    {
+        foreach ( PizzaOrder.MeatItem meatItem in meats )
+        {
+            if ( meatItem.meatType == meatType )
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/Assets/Scripts/Utils/Utilities.cs
+++ b/Assets/Scripts/Utils/Utilities.cs
@@ -16,14 +16,6 @@ public class Utilities
 
     public static bool containsMeat( List<PizzaOrder.MeatItem> meats, Constants.Meats meatType )
     {
-        foreach ( PizzaOrder.MeatItem meatItem in meats )
-        {
-            if ( meatItem.meatType == meatType )
-            {
-                return true;
-            }
-        }
-
-        return false;
+        return ( meats.FindIndex(meatItem => meatItem.meatType == meatType)  != -1 );
     }
 }


### PR DESCRIPTION
Meat delivery sampling should work as follows:
- Create boxes for specified meats
- Say how many boxes we want for the specified meats
- Sample from distribution excluding specified meats

eg. we can say we need pepperoni, give me two boxes of it. I want 4 boxes total. Those last two boxes will be sampled from Set(meat) - pepperoni.